### PR TITLE
Fix string substitution

### DIFF
--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -260,5 +260,5 @@ func updateSection(body, section, message string) (string, error) {
 		return "", err
 	}
 
-	return re.ReplaceAllString(body, msg), nil
+	return re.ReplaceAllLiteralString(body, msg), nil
 }


### PR DESCRIPTION
Substitute replacement directly, without using `Regexp.Expand`.

If the existing comment had `$1` in it, it would be expanded when it should not be.